### PR TITLE
use bullseye container for builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
             arch: 386
     runs-on: ubuntu-latest
     container:
-      image: golang:1.21
+      image: golang:1.22-bullseye
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
In order to build binaries in releases that can run on older glibc versions without triggering
```
./mini-syslog-receiver-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./mini-syslog-receiver-linux-amd64)
./mini-syslog-receiver-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./mini-syslog-receiver-linux-amd64)
```
this PR changes the building container for Linux release binaries to use a bullseye-based one.