### PR TITLE
use automatic format detection

### DIFF
--- a/mini-syslog-receiver.go
+++ b/mini-syslog-receiver.go
@@ -85,7 +85,7 @@ func main() {
 
 			var err error
 			server := syslog.NewServer()
-			server.SetFormat(syslog.RFC5424)
+			server.SetFormat(syslog.Automatic)
 			server.SetHandler(handler)
 
 			addr := fmt.Sprintf("%s:%d", ctx.String("listen"), ctx.Uint64("port"))


### PR DESCRIPTION
This PR changes the format definition to use automatic detection of the syslog flavour, to enable maximum compatibility across versions (RFC3164 or RFC5424 or RFC6587).